### PR TITLE
Output IOTracker info to file instead of to stdout

### DIFF
--- a/single_threaded_runtime/src/lib.rs
+++ b/single_threaded_runtime/src/lib.rs
@@ -95,14 +95,6 @@ impl<R: Reactor> SingleThreadedRuntime<R> {
 
         let mut all_done = false;
         while !all_done {
-            WAITING_TASKS.with(|wt|{
-                let mut v = vec![];
-                for (_, task) in wt.borrow().iter() {
-                    v.push(*task.pid);
-                }
-                trace!("Waiting Tasks: {:?}", v);
-            });
-
             // Block here for actual events to come.
             // After this line, NEXT_TASK should contain the next task :b
             self.reactor.borrow_mut().wait_for_event();


### PR DESCRIPTION
Super simple PR. Adds LogWriter which writes to a file instead of just printing out the IO events. 