### PR TITLE
Use seccomp-bpf filter to specify which system calls to intercept.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -89,8 +89,21 @@ pub(crate) fn run_tracee(command: Command) -> anyhow::Result<()> {
 
     // WARNING: The seccomp filter must be loaded after the call to ptraceme() and
     // raise(...).
-    let loader = seccomp::RuleLoader::new();
-    loader.load_to_kernel();
+    let mut loader = seccomp::RuleLoader::new()?;
+
+    loader.intercept(libc::SYS_fork)?;
+    loader.intercept(libc::SYS_execve)?;
+    loader.intercept(libc::SYS_execveat)?;
+    loader.intercept(libc::SYS_exit)?;
+    loader.intercept(libc::SYS_exit_group)?;
+    loader.intercept(libc::SYS_clone)?;
+    loader.intercept(libc::SYS_clone3)?;
+    loader.intercept(libc::SYS_open)?;
+    loader.intercept(libc::SYS_openat)?;
+    loader.intercept(libc::SYS_read)?;
+    loader.intercept(libc::SYS_write)?;
+    loader.intercept(libc::SYS_vfork)?;
+    loader.load_to_kernel()?;
 
     // Convert arguments to correct arguments.
     let exe = CString::new(command.0).unwrap();

--- a/src/tracer.rs
+++ b/src/tracer.rs
@@ -9,8 +9,8 @@ use nix::unistd::Pid;
 #[derive(Debug, Clone)]
 pub enum TraceEvent {
     Exec(Pid),
-    /// This is the stop before the final, from here we know we will receive an
-    /// actual exit.
+    /// This is a stop before the actual program exit, this is our last chance to ptrace-queries
+    /// on the tracee. From here, we expect to receive a real program exit.
     PreExit(Pid),
     /// This is really a seccomp event, but with our setup, it represents a
     /// prehook event.


### PR DESCRIPTION
- By default all system calls are now allowed. We opt-in to intercepting.
- Have RuleLoader return errors instead of panicking.