### PR TITLE
Change to whitelisting system calls. 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,7 +185,6 @@ dependencies = [
  "nix",
  "seccomp-sys",
  "single_threaded_runtime",
- "stdext",
  "structopt",
  "tracing",
  "tracing-futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,6 @@ authors = ["gatowololo <gatowololo@gmail.com>"]
 edition = "2018"
 
 [dependencies]
-stdext = "0.2.1"
 nix = "0.17"
 libc = "0.2"
 async-trait = "0.1.21"

--- a/src/system_call_names.rs
+++ b/src/system_call_names.rs
@@ -1,4 +1,15 @@
-pub static SYSTEM_CALL_NAMES: [&str; 332] = [
+use crate::context;
+use anyhow;
+use anyhow::Context;
+
+pub fn get_syscall_name(number: usize) -> anyhow::Result<&'static str> {
+    let name = SYSTEM_CALL_NAMES
+        .get(number as usize)
+        .with_context(|| context!("System call number {} out of bounds.", number))?;
+    Ok(*name)
+}
+
+static SYSTEM_CALL_NAMES: [&str; 332] = [
     "read",
     "write",
     "open",

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,39 @@
+#[macro_export]
+/// Simple macro that adds the current function's name to a string. Meant to be used with
+/// anyhow::with_context.
+/// Instead of having to write:
+///
+/// We can just write:
+///
+/// Basically wraps the format!() macro adding prepending the function name to the string.
+/// Functions exactly like format!().
+macro_rules! context {
+    ($str_literal:expr, $($arg:expr),*) => {
+        format!(concat!("{}(): ", $str_literal, " file: {}, line: {}."),
+                   crate::function_name!(), $($arg),*, std::file!(), std::line!())
+    };
+    ($str_literal:expr) => {
+        format!(concat!("{}(): ", $str_literal, " file: {}, line: {}."),
+                   crate::function_name!(), std::file!(), std::line!())
+    };
+}
+
+#[macro_export]
+/// Return function name.
+/// If this is called from a closure so we omit everything else. So instead of:
+/// io_tracker::execution::do_run_process::{{closure}}::{{closure}}:
+/// we get:
+///io_tracker::execution::do_run_process
+macro_rules! function_name {
+    () => {{
+        fn f() {}
+        fn type_name_of<T>(_: T) -> &'static str {
+            std::any::type_name::<T>()
+        }
+        let name = type_name_of(f);
+        match &name[..name.len()].find("::{{closure}}") {
+            Some(pos) => &name[..*pos],
+            None => &name[..name.len() - 3],
+        }
+    }};
+}


### PR DESCRIPTION
As promised here is the whitelist mode! So far, it allows `ls` through. We should run more programs and whitelist more common system calls.

Add support for better error messages via pseudo-stacktraces. See #27 for more info.

Closes #25