### PR TITLE
Better error reporting for failure to write to cache.

### DIFF
--- a/src/execution.rs
+++ b/src/execution.rs
@@ -50,7 +50,8 @@ pub fn trace_program(first_proc: Pid) -> Result<()> {
     // PendingRoot == we skipped the execution because
     // it had a cached match and was therefore skippable.
     if !first_execution.is_pending_root() {
-        serialize_execs_to_cache(first_execution.clone())?;
+        serialize_execs_to_cache(first_execution.clone())
+            .with_context(|| context!("Unable to serialize execs to our cache file."))?;
     }
     println!(
         "number of child execs: {}",

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,9 +79,11 @@ fn run_tracer_and_tracee(command: Command) -> anyhow::Result<()> {
                 .with_context(|| context!("Unable to wait for child to be ready"))?;
 
             debug!("Child returned ready!");
-            Ptracer::set_trace_options(tracee_pid)?;
+            Ptracer::set_trace_options(tracee_pid).
+                with_context(|| context!("Unable to set ptracing options."))?;
 
-            execution::trace_program(tracee_pid)?;
+            execution::trace_program(tracee_pid).
+                with_context(|| context!("Failed while tracing program."))?;
             Ok(())
         }
         ForkResult::Child => run_tracee(command),


### PR DESCRIPTION
Running a command like `cargo run -- /usr/bin/echo "foo"` is currently failing for me with the error:
```
foo
Error: No such file or directory (os error 2)
```

This PR adds extra error context to produce:
```rust
Error: io_tracker::run_tracer_and_tracee(): Failed while tracing program. file: src/main.rs, line: 86.

Caused by:
    0: io_tracker::execution::trace_program(): Unable to serialize execs to our cache file. file: src/execution.rs, line: 54.
    1: io_tracker::cache::serialize_execs_to_cache(): Cannot write to cache location: "./IOTracker/cache/cache". file: src/cache.rs, line: 815.
    2: No such file or directory (os error 2)
```

This PR doesn't fix the error. Instead just provides better logging. See #58 for info on fixing the actual error.