### PR TITLE
add original umask to precondition

### DIFF
--- a/src/condition_generator.rs
+++ b/src/condition_generator.rs
@@ -282,7 +282,7 @@ fn check_fact_holds(fact: Fact, path_name: PathBuf, pid: Pid) -> bool {
                 let current_umask: u32 = fs::read_to_string(&status_file).unwrap()
                     .split("\n")
                     .filter(|l| l.starts_with("Umask:"))
-                    .map(|l| l.split_once(":").unwrap().1.parse::<u32>().unwrap())
+                    .map(|l| l.split_once(":").unwrap().1.trim().parse::<u32>().unwrap())
                     .collect::<Vec<u32>>()
                     .pop().unwrap();
                 current_umask == original_umask

--- a/src/condition_utils.rs
+++ b/src/condition_utils.rs
@@ -82,6 +82,7 @@ pub enum Fact {
     StartingContents(Vec<u8>),
     StatFsStructMatches(MyStatFs),
     StatStructMatches(Stat),
+    OriginalUmask(u32),
 }
 
 #[derive(Clone, Eq, PartialEq)]
@@ -264,6 +265,7 @@ impl FirstState {
                 }
                 SyscallEvent::Stat(_, SyscallOutcome::Fail(_)) => (),
                 SyscallEvent::Statfs(_, _) => (),
+                SyscallEvent::Umask(_) => (),
             }
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -167,7 +167,7 @@ fn our_seccomp_rules() -> anyhow::Result<()> {
     loader.intercept(libc::SYS_stat)?;
     loader.intercept(libc::SYS_statfs)?;
     loader.intercept(libc::SYS_vfork)?;
-    // loader.intercept(libc::SYS_umask)?;
+    loader.intercept(libc::SYS_umask)?;
     loader.intercept(libc::SYS_unlink)?;
     loader.intercept(libc::SYS_unlinkat)?;
 
@@ -227,7 +227,7 @@ fn our_seccomp_rules() -> anyhow::Result<()> {
     loader.let_pass(libc::SYS_sysinfo)?;
     loader.let_pass(libc::SYS_statx)?;
     loader.let_pass(libc::SYS_times)?;
-    loader.let_pass(libc::SYS_umask)?;
+    //loader.let_pass(libc::SYS_umask)?;
     loader.let_pass(libc::SYS_utimensat)?;
     loader.let_pass(libc::SYS_wait4)?;
     loader.let_pass(libc::SYS_write)?;

--- a/src/regs.rs
+++ b/src/regs.rs
@@ -62,6 +62,7 @@ macro_rules! implement_register_cast {
 implement_register_cast!(u64);
 implement_register_cast!(usize);
 implement_register_cast!(i32);
+implement_register_cast!(u32);
 
 /// Allow a register to be cast to an arbitrary pointer type. Traits + generics are so cool!
 impl<T> RegisterCast for *const T {

--- a/src/syscalls.rs
+++ b/src/syscalls.rs
@@ -57,6 +57,7 @@ pub enum SyscallEvent {
     Rename(PathBuf, PathBuf, SyscallOutcome),            // Old, new, outcome
     Stat(Option<Stat>, SyscallOutcome), // Can fail access denied (exec/search on dir) or file didn't exist
     Statfs(Option<MyStatFs>, SyscallOutcome), // Can fail access denied (exec/search on dir) or dir doesn't exist.
+    Umask(u32), // original umask
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]


### PR DESCRIPTION
I've added some code to handle `umask` (see #76), recording a process' original umask (the value returned by the first `umask` syscall) as a new Fact in the precondition.

Then, during skipping, I want to check the child's current umask value (from `/proc/<child-pid>/status`) to see if it matches the cached value. However, I'm not reading the right file at src/condition_generator.rs:278. I was trying to use the pid passed to `check_fact_holds()` but probably that isn't right, as I'm getting a file-not-found error and that pid indeed doesn't exist.