### PR TITLE
add original umask to precondition

### DIFF
--- a/c_examples/umask.c
+++ b/c_examples/umask.c
@@ -1,0 +1,9 @@
+
+#include <sys/stat.h>
+#include <stdio.h>
+
+int main() {
+  mode_t u = umask(0);
+  //printf("sizeof(mode_t) == %ld bytes\n", sizeof(mode_t));
+  return u | S_IWOTH;
+}

--- a/src/cache_utils.rs
+++ b/src/cache_utils.rs
@@ -36,7 +36,7 @@ impl CachedExecMetadata {
             command,
             env_vars,
             starting_cwd,
-            starting_umask
+            starting_umask,
         }
     }
 

--- a/src/cache_utils.rs
+++ b/src/cache_utils.rs
@@ -20,6 +20,7 @@ pub struct CachedExecMetadata {
     // so I am not making sure it's the abosolute path.
     // May want to do that in the future?
     starting_cwd: PathBuf,
+    starting_umask: u32,
 }
 
 impl CachedExecMetadata {
@@ -28,12 +29,14 @@ impl CachedExecMetadata {
         command: Command,
         env_vars: Vec<String>,
         starting_cwd: PathBuf,
+        starting_umask: u32,
     ) -> CachedExecMetadata {
         CachedExecMetadata {
             caller_pid,
             command,
             env_vars,
             starting_cwd,
+            starting_umask
         }
     }
 
@@ -47,6 +50,10 @@ impl CachedExecMetadata {
 
     pub fn starting_cwd(&self) -> PathBuf {
         self.starting_cwd.clone()
+    }
+
+    pub fn starting_umask(&self) -> u32 {
+        self.starting_umask
     }
 }
 

--- a/src/execution.rs
+++ b/src/execution.rs
@@ -334,7 +334,9 @@ pub async fn trace_process(
                                             );
                                             if full_tracking_on {
                                                 entry.check_all_preconditions_regardless()
-                                            } else if entry.check_all_preconditions(tracer.curr_proc) {
+                                            } else if entry
+                                                .check_all_preconditions(tracer.curr_proc)
+                                            {
                                                 // Check if we should skip this execution.
                                                 // If we are gonna skip, we have to change:
                                                 // rax, orig_rax, arg1

--- a/src/execution.rs
+++ b/src/execution.rs
@@ -334,7 +334,7 @@ pub async fn trace_process(
                                             );
                                             if full_tracking_on {
                                                 entry.check_all_preconditions_regardless()
-                                            } else if entry.check_all_preconditions() {
+                                            } else if entry.check_all_preconditions(tracer.curr_proc) {
                                                 // Check if we should skip this execution.
                                                 // If we are gonna skip, we have to change:
                                                 // rax, orig_rax, arg1

--- a/src/execution_utils.rs
+++ b/src/execution_utils.rs
@@ -342,12 +342,14 @@ pub fn path_from_fd(pid: Pid, fd: i32) -> anyhow::Result<PathBuf> {
 
 pub fn get_umask(pid: &Pid) -> u32 {
     let status_file = format!("/proc/{}/status", pid.as_raw());
-    let umask: u32 = fs::read_to_string(&status_file).expect(&format!("error reading {}", status_file))
+    let umask: u32 = fs::read_to_string(&status_file)
+        .expect(&format!("error reading {}", status_file))
         .split("\n")
         .filter(|l| l.starts_with("Umask:"))
         .map(|l| u32::from_str_radix(l.split_once(":").unwrap().1.trim(), 8).unwrap())
         .collect::<Vec<u32>>()
-        .pop().unwrap();
+        .pop()
+        .unwrap();
     debug!("recording umask 0{:o}", umask);
     umask
 }

--- a/src/recording.rs
+++ b/src/recording.rs
@@ -3,6 +3,7 @@ use crate::{
     cache_utils::{hash_command, CachedExecMetadata, Command},
     condition_generator::{generate_preconditions, Accessor, ExecFileEvents},
     condition_utils::{Fact, Postconditions},
+    execution_utils::get_umask,
     syscalls::SyscallEvent,
 };
 use nix::unistd::Pid;
@@ -38,16 +39,19 @@ pub struct ExecMetadata {
     // so I am not making sure it's the abosolute path.
     // May want to do that in the future?
     starting_cwd: PathBuf,
+    starting_umask: u32,
 }
 
 impl ExecMetadata {
     pub fn new(caller_pid: Proc) -> ExecMetadata {
+        let pid = caller_pid.0.clone();
         ExecMetadata {
             caller_pid,
             command: Command(String::new(), Vec::new()),
             cwd: PathBuf::new(),
             env_vars: Vec::new(),
             starting_cwd: PathBuf::new(),
+            starting_umask: get_umask(&pid),
         }
     }
 
@@ -188,6 +192,7 @@ impl Execution {
             command_key.clone(),
             self.env_vars(),
             self.starting_cwd(),
+            self.starting_umask(),
         );
         let mut new_cached_exec = CachedExecution::new(
             cached_metadata,
@@ -250,6 +255,10 @@ impl Execution {
 
     pub fn starting_cwd(&self) -> PathBuf {
         self.successful_exec.starting_cwd()
+    }
+
+    pub fn starting_umask(&self) -> u32 {
+        self.successful_exec.starting_umask
     }
 
     fn set_to_ignored(&mut self, exec_metadata: ExecMetadata) {


### PR DESCRIPTION
Second attempt at #76, building on @krs85's feedback on #84.

The `umask` for a process is recorded in `CachedExecMetadata` (by fishing the value out of `/proc/<pid>/status`). We can only skip if the `umask` matches what we have cached. No `umask` system calls need to be intercepted.