### PR TITLE
Child count as precond

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,7 +1,7 @@
 use crate::{
     cache_utils::{
         create_dirs, delete_dirs, hash_command, number_of_child_cache_subdirs, rename_dirs,
-        CachedExecMetadata, Command,
+        CachedExecMetadata, ExecCommand,
     },
     condition_generator::{check_preconditions, Accessor},
     condition_utils::{Fact, Postconditions, Preconditions},
@@ -22,7 +22,7 @@ use tracing::{debug, error, info, span, trace, Level};
 
 // TODO:
 // pub type CacheMap = HashMap<Command, Vec<RcCachedExec>>;
-pub type CacheMap = HashMap<Command, RcCachedExec>;
+pub type CacheMap = HashMap<ExecCommand, RcCachedExec>;
 
 // The executable path and args
 // are the key to the map.
@@ -201,7 +201,7 @@ impl CachedExecution {
         }
     }
 
-    pub fn command(&self) -> Command {
+    pub fn command(&self) -> ExecCommand {
         self.cached_metadata.command()
     }
 

--- a/src/cache_utils.rs
+++ b/src/cache_utils.rs
@@ -18,7 +18,7 @@ use crate::{condition_generator::Accessor, condition_utils::Fact};
 pub struct CachedExecMetadata {
     caller_pid: SessionId,
     child_exec_count: u32,
-    command: Command,
+    command: ExecCommand,
     env_vars: Vec<String>,
     // Currently this is just the first argument to execve
     // so I am not making sure it's the abosolute path.
@@ -31,7 +31,7 @@ impl CachedExecMetadata {
     pub fn new(
         caller_pid: SessionId,
         child_exec_count: u32,
-        command: Command,
+        command: ExecCommand,
         env_vars: Vec<String>,
         starting_cwd: PathBuf,
         starting_umask: u32,
@@ -54,7 +54,7 @@ impl CachedExecMetadata {
         self.child_exec_count
     }
 
-    pub fn command(&self) -> Command {
+    pub fn command(&self) -> ExecCommand {
         self.command.clone()
     }
 
@@ -68,15 +68,15 @@ impl CachedExecMetadata {
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
-pub struct Command(pub String, pub Vec<String>);
+pub struct ExecCommand(pub String, pub Vec<String>);
 
-impl Command {
+impl ExecCommand {
     pub fn new(exe: String, args: Vec<String>) -> Self {
-        Command(exe, args)
+        ExecCommand(exe, args)
     }
 }
 
-pub fn number_of_child_cache_subdirs(root_exec_command: Command) -> u32 {
+pub fn number_of_child_cache_subdirs(root_exec_command: ExecCommand) -> u32 {
     // Create the root exec's cache subdir path.
     let hashed_root_exec_command = hash_command(root_exec_command);
     let cache_dir = PathBuf::from("./cache");
@@ -182,7 +182,7 @@ pub fn generate_hash(path: PathBuf) -> Vec<u8> {
     }
 }
 
-pub fn hash_command(command: Command) -> u64 {
+pub fn hash_command(command: ExecCommand) -> u64 {
     let mut hasher = DefaultHasher::new();
     command.hash(&mut hasher);
 

--- a/src/execution.rs
+++ b/src/execution.rs
@@ -32,7 +32,7 @@ use crate::{
     syscalls::Stat,
 };
 use crate::{
-    cache_utils::{hash_command, Command},
+    cache_utils::{hash_command, ExecCommand},
     condition_generator::generate_postconditions,
     recording::{append_file_events, copy_output_files_to_cache},
 };
@@ -152,7 +152,7 @@ pub fn trace_program(first_proc: Pid, full_tracking_on: bool) -> Result<()> {
         serialize_execs_to_cache(cache_map.clone());
 
         // for (command, cached_exec) in cache_map {
-        //     println!("Command: {:?}", command);
+        //     println!("ExecCommand: {:?}", command);
 
         //     let preconditions = cached_exec.preconditions();
         //     let postconditions = cached_exec.postconditions();
@@ -336,7 +336,7 @@ pub async fn trace_process(
                                 };
                                 debug!("Execve event, executable: {:?}", exec_path_buf);
 
-                                // let command = Command(
+                                // let command = ExecCommand(
                                 //     exec_path_buf
                                 //         .clone()
                                 //         .into_os_string()
@@ -345,11 +345,11 @@ pub async fn trace_process(
                                 //     args.clone(),
                                 // );
                                 // let hashed_command = hash_command(command.clone());
-                                // debug!("HASHED COMMAND: {:?}", hashed_command);
+                                // panic!("EXECCOMMAND: {:?}, HASHED COMMAND: {:?}", command, hashed_command);
                                 // Check the cache for the thing
                                 if !FACT_GEN {
                                     if let Some(cache) = retrieve_existing_cache() {
-                                        let command = Command(
+                                        let command = ExecCommand(
                                             exec_path_buf
                                                 .clone()
                                                 .into_os_string()
@@ -519,7 +519,7 @@ pub async fn trace_process(
                                     if !(PTRACE_ONLY || FACT_GEN) {
                                         let exec = curr_execution.executable();
                                         let args = curr_execution.args();
-                                        let comm_hash = hash_command(Command(exec, args));
+                                        let comm_hash = hash_command(ExecCommand(exec, args));
                                         let cache_subdir = fs::canonicalize("./cache").unwrap();
                                         let cache_subdir =
                                             cache_subdir.join(format!("{:?}", comm_hash));

--- a/src/execution_utils.rs
+++ b/src/execution_utils.rs
@@ -16,8 +16,7 @@ use nix::{
 use tracing::debug;
 
 use crate::{
-    cache_utils::{hash_command, Command},
-    condition_generator::ExecSyscallEvents,
+    cache_utils::{hash_command, ExecCommand},
     context,
     recording::{LinkType, RcExecution},
     syscalls::{
@@ -213,7 +212,7 @@ fn copy_input_file_to_cache(curr_execution: &RcExecution, input_file_path: PathB
     let cache_dir = PathBuf::from(CACHE_LOCATION);
     let input_str = PathBuf::from("input_files");
 
-    let command = Command(curr_execution.executable(), curr_execution.args());
+    let command = ExecCommand(curr_execution.executable(), curr_execution.args());
     let hashed_command = hash_command(command);
     let cache_subdir_hashed_command = cache_dir.join(hashed_command.to_string());
     let cache_subdir_hashed_command_inputs_dir = cache_subdir_hashed_command.join(input_str);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use cache_utils::Command;
+use cache_utils::ExecCommand;
 use tracing_subscriber::filter::EnvFilter;
 
 mod async_runtime;
@@ -64,7 +64,7 @@ fn main() -> anyhow::Result<()> {
     // TODO: get starting cwd of first exec
     let opt = Opt::from_args();
     let full_tracking_on = opt.full_tracking;
-    let command = Command::new(opt.exe, opt.args);
+    let command = ExecCommand::new(opt.exe, opt.args);
 
     run_tracer_and_tracee(command, full_tracking_on)?;
     Ok(())
@@ -74,7 +74,7 @@ fn main() -> anyhow::Result<()> {
 // we do all the tracing,
 // we do all iterative (repetitive) precondition checking,
 // and let it run normally in between.
-fn run_tracer_and_tracee(command: Command, full_tracking_on: bool) -> anyhow::Result<()> {
+fn run_tracer_and_tracee(command: ExecCommand, full_tracking_on: bool) -> anyhow::Result<()> {
     use nix::sys::wait::waitpid;
 
     match fork()? {
@@ -97,7 +97,7 @@ fn run_tracer_and_tracee(command: Command, full_tracking_on: bool) -> anyhow::Re
 
 /// This function should be called after a fork.
 /// uses execve to call the tracee program and have it ready to be ptraced.
-pub(crate) fn run_tracee(command: Command) -> anyhow::Result<()> {
+pub(crate) fn run_tracee(command: ExecCommand) -> anyhow::Result<()> {
     use nix::sys::signal::raise;
     use std::ffi::CStr;
 


### PR DESCRIPTION
We should be sure the root exec's cache subdir contains all the child exec's subdirs before determining we can skip the root.